### PR TITLE
Trac: Send notices instead of normal messages

### DIFF
--- a/matrixbot/plugins/trac.py
+++ b/matrixbot/plugins/trac.py
@@ -51,7 +51,7 @@ class TracPlugin:
         message = "\n".join(res)
         for room_id in self.settings["rooms"]:
             room_id = self.bot.get_real_room_id(room_id)
-            handler(room_id, message)
+            self.bot.send_notice(room_id, message)
 
     def command(self, sender, room_id, body, handler):
         self.logger.debug("TracPlugin command")


### PR DESCRIPTION
Send notice events instead of message events when providint ticket information. Using normal messages for automated messages is distracting for on-going  conversations, and moreover the [Matrix spec](http://matrix.org/docs/spec/client_server/r0.2.0.html#m-notice) explicitly mandates using `m.notice` events:

> It is intended to be used by automated clients, such as bots, bridges, and other entities, rather than humans.