### PR TITLE
Do not recover if exception

### DIFF
--- a/matrixbot/plugins/wktestbotsfeeder.py
+++ b/matrixbot/plugins/wktestbotsfeeder.py
@@ -73,6 +73,12 @@ class WKTestBotsFeederPlugin:
                 return True
         return False
 
+    def was_exception(self, build):
+        for each in build['text']:
+            if (re.search('exception', each, re.IGNORECASE)):
+                return True
+        return False
+
     def summary(self, build):
         return " ".join(build['text'])
 
@@ -99,7 +105,7 @@ class WKTestBotsFeederPlugin:
                     continue
 
                 if ('failed' in builder and builder['failed']) and not failed:
-                    builder["recovery"] = True
+                    builder["recovery"] = not self.was_exception(b)
                 else:
                     builder["recovery"] = False
 


### PR DESCRIPTION
The plugin is considering that whenever a build didn't fail, then the bot recovered.

However, there's a case where this leads to a false positive and it's the case when one or more build failed and then the next one was ended with an exception (by pressing Cancel in the UI, for instance). In that case, the plugin considers the bot has recovered but it should remain on the same state as before.

For instance, this build was considered a recovering after several failures https://build.webkit.org/builders/GTK%20Linux%2064-bit%20Release%20%28Tests%29/builds/13504. Another one: https://build.webkit.org/builders/GTK%20Linux%2064-bit%20Debug%20%28Tests%29

In summary, I think the way of managing this "exception" state is a neutral value.