### PR TITLE
Allow builders define what building step to monitor 

### DIFF
--- a/cfg/matrix-bot.cfg.example
+++ b/cfg/matrix-bot.cfg.example
@@ -103,8 +103,12 @@ settings["allowed-join"] = {
 #         "WPE Linux 64-bit Release (Build)": {
 #             "last_buildjob_url_squema": "https://build.webkit.org/builders/%(builder_name)s/builds/%(last_buildjob)s",
 #             "builds_url_squema": "https://build.webkit.org/json/builders/%(builder_name)s/builds?select=-2&as_text=1",
-#             "builder_name": 'WPE Linux 64-bit Release (Build)',
-#             "only_failures": False
+#             "builder_name": "WPE Linux 64-bit Release (Build)",
+#             "only_failures": False,
+#             "target_step": {
+#               "name": "compile-webkit",
+#               "text": "compiled"
+#             }
 #         },
 # }
 # settings["plugins"]["plugin_feeder"] = plugin_feeder

--- a/matrixbot/plugins/wkbotsfeeder.py
+++ b/matrixbot/plugins/wkbotsfeeder.py
@@ -67,7 +67,7 @@ class WKBotsFeederPlugin:
             res += self.format("success", color="green", strong="")
         return res
 
-    def sent(self, message):
+    def send(self, message):
         for room_id in self.settings["rooms"]:
             room_id = self.bot.get_real_room_id(room_id)
             self.bot.send_html(room_id, message, msgtype="m.notice")
@@ -116,7 +116,7 @@ class WKBotsFeederPlugin:
 
                 if self.should_send_message(builder, failed):
                     message = self.pretty_entry(builder)
-                    self.sent(message)
+                    self.send(message)
             except Exception as e:
                 self.logger.error("WKBotsFeederPlugin got error in builder %s: %s" % (builder_name,e))
 


### PR DESCRIPTION
There are builders, such as the JSCOnly builders, that build and test. We use this plugin mostly for monitor that status of bots that build only. I would like to determine whether a JSCOnly bot was successful by evaluating the status of the 'compile-webkit' step, and not the general status of the build.

To do that, builders can now define a 'target_step' to watch and what text to search for to determine the step was successful. Example:

```python
"builders": {
    "JSCOnly Linux MIPS32el Release",
    "last_buildjob_url_squema": "https://build.webkit.org/builders/%(builder_name)s/builds/%(last_buildjob)s",
    "builds_url_squema": "https://build.webkit.org/json/builders/%(builder_name)s/builds?select=-2&as_text=1",
    "builder_name": "JSCOnly Linux MIPS32el Release",
    "only_failures": False,
    "target_step": {
        "name": "compile-webkit",
        "text": "compiled"
    }
}
```