### PR TITLE
Fix condition that sets recovery status

### DIFF
--- a/matrixbot/plugins/wkbotsfeeder.py
+++ b/matrixbot/plugins/wkbotsfeeder.py
@@ -111,7 +111,7 @@ class WKBotsFeederPlugin:
                     'failed': failed,
                     'last_buildjob': build['number'],
                     'last_comments': build['sourceStamp']['changes'][0]['comments'],
-                    'recovery': 'failed' in builder and not failed
+                    'recovery': 'failed' in builder and builder['failed'] and not failed
                 })
 
                 if self.should_send_message(builder, failed):


### PR DESCRIPTION
Since #26 landed, recovery status for a bot is not reported just once, but always. I think I introduced an error in the computation of the condition that sets the recovery flag.