### PR TITLE
wkbotsfeeder.py: only-failures logic was inversed

### DIFF
--- a/matrixbot/plugins/wkbotsfeeder.py
+++ b/matrixbot/plugins/wkbotsfeeder.py
@@ -73,7 +73,7 @@ class WKBotsFeederPlugin:
             self.bot.send_html(room_id, message, msgtype="m.notice")
 
     def should_send_message(self, builder, failed):
-        return failed or builder['only_failures'] or (builder['notify_recoveries'] and builder['recovery'])
+        return failed or (not builder['only_failures']) or (builder['notify_recoveries'] and builder['recovery'])
 
     def build_failed(self, builder, build):
         return not self.build_succeeded(builder, build)


### PR DESCRIPTION
Another glitch introduced after the refactorization in https://github.com/psaavedra/matrix-bot/commit/fb24c70e2d7be5f736702e0a699b01da0a019724

The logic that checks whether to send a message or not wasn't translated correctly. Right now, the plugin is reporting 'success' statuses for every build. The reason is that the condition that checks 'only-failures' (True in the plugin) should be "not only-failures", so the plugin doesn't send success messages for every build.