### PR TITLE
README.md: Add missing dependency in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install  git+https://github.com/psaavedra/matrix-bot.git
 * Installation for development:
 
 ```
-sudo pip install getconf matrix-client==0.0.6 python-ldap python-memcached feedparser pytz requests
+sudo pip install getconf matrix-client==0.0.6 python-dateutil python-ldap python-memcached feedparser pytz requests
 git clone http://github.com/psaavedra/matrix-bot.git
 cd matrix-bot/
 cd tools/


### PR DESCRIPTION
In the install instructions, dependency of "python-dateutil" is missing.