### PR TITLE
Use async/await to run the main loop of the matrix-bot

### DIFF
--- a/matrixbot/ldap.py
+++ b/matrixbot/ldap.py
@@ -74,6 +74,7 @@ the settings
         return list(filter((lambda x: x in ldap_groups), list(map(get_uid, res))))
     except Exception as e:
         logger.error("Error getting groups from LDAP: %s (%s)" % (e, ldap_server))
+    return []
 
 
 def get_ldap_groups_members(ldap_settings):

--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -198,7 +198,7 @@ class MatrixBot():
                 "Simulated '%s' action in room '%s' over: %s" % (
                     action,
                     target_room_id,
-                    " ".join(selected_users)),
+                    utils.list_to_str(selected_users)),
                 room_id)
         else:
             if len(selected_users) > 0:
@@ -214,7 +214,7 @@ class MatrixBot():
                     msg = '''Action '%s' in room %s over %s''' % (
                         action,
                         target_room_id,
-                        " ".join(selected_users)
+                        utils.list_to_str(selected_users)
                     )
                     self.send_private_message(sender, msg, room_id)
             elif sender:

--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -274,7 +274,7 @@ class MatrixBot():
     def send_private_message(self, user_id, message, room_id=None):
         # Just add a first case: if the channel is 1-to-1 then reply
         # directly using this channel
-        if self.is_private_room(room_id, self.get_user_id(), user_id):
+        if room_id and self.is_private_room(room_id, self.get_user_id(), user_id):
             return self.call_api("send_message", 3, room_id, message)
 
         user_room_id = self.get_private_room_with(user_id)

--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -245,7 +245,7 @@ class MatrixBot():
                 self.logger.debug("Fail (%s/%s) in call %s action with: %s - %s" % (attempts, max_attempts, action, args, e))
                 attempts -= 1
                 time.sleep(5)
-        return str(e)
+        return None
 
     def send_emote(self, room_id, message):
         return self.call_api("send_emote", 3,

--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -8,8 +8,10 @@ from matrix_client.api import MatrixRequestError
 from matrix_client.client import MatrixClient
 from matrix_client.room import Room
 
+import asyncio
 # import pprint
 import time
+import traceback
 import re
 
 from . import utils
@@ -284,6 +286,20 @@ class MatrixBot():
                 "Replying command as PM to %s" % user_id)
         return self.call_api("send_message", 3,
                              user_room_id, message)
+
+    async def loop(self):
+        await self.sync(ignore=True)  # Ignoring pending old messages
+        while True:
+            try:
+                task = asyncio.ensure_future(self.sync())
+                await asyncio.sleep(self.period)
+                try:
+                    await task
+                except asyncio.CancelledError as e:
+                    self.logger.error("matrixbot: Sync cancelled: %s" % e)
+            except Exception as e:
+                self.logger.error("matrixbot: Unexpected error: %s" % e)
+                self.logger.error("matrixbot: Unexpected error: %s" % traceback.print_exc())
 
     def leave_empty_rooms(self):
         self.logger.debug("leave_empty_rooms")
@@ -713,28 +729,44 @@ Available command aliases:
     def get_room_aliases(self, room_id):
         return self.room_aliases[room_id] if room_id in self.room_aliases else []
 
-    def sync(self, ignore=False, timeout_ms=30000):
-        response = self.client.api.sync(self.sync_token, timeout_ms, full_state='true')
-        self._set_rooms(response)
-        self.sync_token = response["next_batch"]
-        self.logger.info("!!! sync_token: %s" % (self.sync_token))
-        self.logger.log(EXTRA_DEBUG, "Sync response: %s" % (response))
+    async def _dispatch(self, response):
+        _tasks = []
 
+        if not response:
+            return
+
+        async def _(plugin, callback):
+            try:
+                plugin.dispatch(callback)
+            except Exception as e:
+                self.logger.error(
+                    "Error in plugin %s: %s" % (plugin.name, e)
+                )
+
+        for plugin in self.plugins:
+            _tasks.append(asyncio.create_task(_(plugin, self.send_message)))
+        _tasks.append(asyncio.ensure_future(
+            self.sync_invitations(response['rooms']['invite'])))
+        _tasks.append(asyncio.ensure_future(
+            self.sync_joins(response['rooms']['join'])))
+        for task in _tasks:
+            await task
+
+    async def sync(self, ignore=False, timeout_ms=30000):
+        response = None
+        try:
+            response = self.client.api.sync(self.sync_token, timeout_ms, full_state='true')
+            self._set_rooms(response)
+            self.sync_token = response["next_batch"]
+            self.logger.info("!!! sync_token: %s" % (self.sync_token))
+            self.logger.log(EXTRA_DEBUG, "Sync response: %s" % (response))
+        except Exception as e:
+            self.logger.error("Error in sync: %s" % e)
         if not ignore:
-            # dispatch to plugins
-            for plugin in self.plugins:
-                try:
-                    plugin.dispatch(self.send_message)
-                except Exception as e:
-                    self.logger.error(
-                        "Error in plugin %s: %s" % (plugin.name, e)
-                    )
-            # core
-            self.sync_invitations(response['rooms']['invite'])
-            self.sync_joins(response['rooms']['join'])
-        time.sleep(self.period)
+            await self._dispatch(response)
 
-    def sync_invitations(self, invite_events):
+    async def sync_invitations(self, invite_events):
+        _tasks = []
         # TODO Clean code and also use only_local_domain setting
         for room_id, invite_state in list(invite_events.items()):
             self.logger.info("+++ (invite) %s" % (room_id))
@@ -745,15 +777,25 @@ Available command aliases:
                         event["content"]["membership"] == 'invite' and \
                         "sender" in event and \
                         event["sender"].endswith(self.domain):
-                    self.call_api("join_room", 3, room_id)
+                    _tasks.append(asyncio.create_task(
+                        self.call_api("join_room", 3, room_id)
+                    ))
+        for task in _tasks:
+            await task
 
-    def sync_joins(self, join_events):
+
+    async def sync_joins(self, join_events):
+        _tasks = []
         for room_id, sync_room in list(join_events.items()):
             self.logger.debug(">>> (join) %s" % (room_id))
             for event in sync_room["timeline"]["events"]:
-                self._process_event(room_id, event)
+                _tasks.append(asyncio.ensure_future(
+                    self._process_event(room_id, event)
+                ))
+        for task in _tasks:
+            await task
 
-    def _process_event(self, room_id, event):
+    async def _process_event(self, room_id, event):
         if not (
             event["type"] == 'm.room.message'
             and "content" in event

--- a/matrixbot/utils.py
+++ b/matrixbot/utils.py
@@ -150,6 +150,10 @@ def pp(text, **kwargs):
    return ret.format(content=text)
 
 
+def list_to_str(l):
+    return " ".join(l) if len(l) > 0 else "no one"
+
+
 class MockBot:
     def __init__(self):
         pass

--- a/tools/matrix-bot
+++ b/tools/matrix-bot
@@ -6,7 +6,7 @@
 # Contact: saavedra.pablo at gmail.com
 
 import argparse
-import traceback
+import asyncio
 import time
 
 from matrixbot import utils
@@ -29,14 +29,6 @@ logger = utils.create_logger(settings)
 
 ## main ########################################################################
 if __name__ == '__main__':
-    while True:
-        try:
-            m = matrix.MatrixBot(settings)
-            m.join_rooms(silent=True)
-            m.sync(ignore=True) # Ignoring pending old messages
-            while True:
-                m.sync()
-        except Exception as e:
-            logger.error("Unexpected error: %s" % e)
-            logger.error("Unexpected error: %s" % traceback.print_exc())
-            time.sleep(10)
+    m = matrix.MatrixBot(settings)
+    m.join_rooms(silent=True)
+    asyncio.run(m.loop())


### PR DESCRIPTION
**Motivation:**

The main loop logic is synchronous even when many logic could be executed in pararell

**Change:**

rework of the code using async/await 


**Other considerations**:

This change also requires the python environment updated to 3.7 (at least): https://github.com/psaavedra/matrix-bot/pull/45
* This change address the issue https://github.com/psaavedra/matrix-bot/issues/22

**How to set the environment**:

```
cd matrix-bot
virtualenv -p python3 test_env
. test_env/bin/activate
export PYTHONPATH=$(pwd):$PYTHONPATH
tools/matrix-bot  -c matrixbot.conf
```