### PR TITLE
Adapt WKBotsFeeder plugin to new buildbot API

### DIFF
--- a/matrixbot/plugins/wkbotsfeeder.py
+++ b/matrixbot/plugins/wkbotsfeeder.py
@@ -15,7 +15,7 @@ if os.path.dirname(__file__) == "matrixbot/plugins":
 
 from matrixbot import utils
 
-put = sys.stdout.write
+puts = utils.puts
 
 
 def utcnow():
@@ -166,7 +166,7 @@ def test_async(plugin):
     print("Ok")
 
 def test_can_fetch_last_build(plugin):
-    put("test_can_fetch_last_build: ")
+    puts("test_can_fetch_last_build: ")
     builder = plugin.settings['builders']["GTK-Linux-64-bit-Release-Ubuntu-LTS-Build"]
     build = plugin.get_last_build(builder)
     assert(build)

--- a/matrixbot/utils.py
+++ b/matrixbot/utils.py
@@ -10,6 +10,8 @@ import logging
 import copy
 import memcache
 
+puts = sys.stdout.write
+
 def get_default_settings():
     settings = {}
     settings["DEFAULT"] = {
@@ -118,4 +120,4 @@ class MockBot:
         return room_id or 0
 
     def send_html(self, room_id, message, **kwargs):
-        sys.stdout.write("Room #{}: {}".format(room_id, message))
+        puts("Room #{}: {}".format(room_id, message))

--- a/matrixbot/utils.py
+++ b/matrixbot/utils.py
@@ -108,3 +108,14 @@ def get_command_alias(message, settings):
 def get_aliases(settings):
     res = copy.copy(settings["aliases"])
     return res
+
+
+class MockBot:
+    def __init__(self):
+        pass
+
+    def get_real_room_id(self, room_id):
+        return room_id or 0
+
+    def send_html(self, room_id, message, **kwargs):
+        sys.stdout.write("Room #{}: {}".format(room_id, message))


### PR DESCRIPTION
Recently build.webkit.org has updated to buildbot 2.10, which uses a new JSON API (See: http://docs.buildbot.net/current/developer/rest.html).

This PR is WIP. I'm testing these changes locally, but I need to wait for results to verify it's working correctly.