### PR TITLE
wkbotsfeeder: Allow a builder determine success depending on the value of a build step

### DIFF
--- a/matrixbot/plugins/wkbotsfeeder.py
+++ b/matrixbot/plugins/wkbotsfeeder.py
@@ -12,8 +12,7 @@ if os.path.dirname(__file__) == "matrixbot/plugins":
 
 from matrixbot import utils
 
-set_property = utils.set_property
-puts = utils.puts
+pp, puts, set_property = utils.pp, utils.puts, utils.set_property
 
 class WKBotsFeederPlugin:
     def __init__(self, bot, settings):
@@ -42,11 +41,11 @@ class WKBotsFeederPlugin:
         res += "%(last_buildjob)s </a>): " % builder
 
         if builder['recovery']:
-            res += self.format("recovery", color="green", strong="")
+            res += pp("recovery", color="green", strong="")
         elif builder['failed']:
-            res += self.format("failed", color="red", strong="")
+            res += pp("failed", color="red", strong="")
         else:
-            res += self.format("success", color="green", strong="")
+            res += pp("success", color="green", strong="")
         return res
 
     def last_build_url(self, builder):

--- a/matrixbot/plugins/wkbotsfeeder.py
+++ b/matrixbot/plugins/wkbotsfeeder.py
@@ -19,6 +19,9 @@ class WKBotsFeederPlugin:
         self.name = "WKBotsFeederPlugin"
         self.logger = utils.get_logger()
         self.bot = bot
+        self.load(settings)
+
+    def load(self, settings):
         self.settings = settings
         self.logger.info("WKBotsFeederPlugin loaded (%(name)s)" % settings)
         for builder_name, builder in list(self.settings["builders"].items()):
@@ -122,11 +125,24 @@ def selftest():
                 "builderid": 68,
             },
         },
+
     }
     plugin = WKBotsFeederPlugin(utils.MockBot(), settings)
 
     test_dispatch(plugin)
     test_can_fetch_last_build(plugin)
+
+    settings["builders"] = {
+        "JSCOnly-Linux-MIPS32el-Release": {
+            "builderid": 31,
+            "target_step": {
+                "name": "compile-webkit",
+                "text": "compiled"
+            }
+        }
+    }
+    plugin.load(settings)
+    test_dispatch(plugin)
 
 def test_dispatch(plugin):
     print("test_dispatch: ")


### PR DESCRIPTION
Sometimes we want to observe a particular step of a build instead of the general state of the build. For instance, we might be interested in observing the compilation step of a builder, and determine success based on that step.