### PR TITLE
Add matrix-digest tool

### DIFF
--- a/cfg/matrix-bot.cfg.example
+++ b/cfg/matrix-bot.cfg.example
@@ -10,6 +10,17 @@ settings["matrix"] = {
   "domain": "matrix.org",
   "rooms": []
 }
+settings["mail"] = {
+        "host": "127.0.0.1",
+        "port": 25,
+        "ssl": False,
+        "subject": "Matrix bot",
+        "from": "bot@domain.com",
+        "username": "username",
+        "password": "password",
+        "to_policy": "deny",  # or allow
+        "to_policy_filter": "all"  # None or ["domain.com", "mailbox@second-domain.com"]
+}
 settings["memcached"] = {
     "ip": "127.0.0.1",
     "port": 11211,

--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -308,8 +308,7 @@ class MatrixBot():
                 3,
                 room_id,
                 "Replying command as PM to %s" % user_id)
-        return self.call_api("send_message", 3,
-                             user_room_id, message)
+        return self.send_message(room_id, message)
 
     async def loop(self):
         loop_pool = []

--- a/matrixbot/utils.py
+++ b/matrixbot/utils.py
@@ -31,6 +31,8 @@ def get_default_settings():
         "from": "bot@domain.com",
         "username": "username",
         "password": "password"
+        "to_policy": "deny",
+        "to_policy_filter": "all",
     }
     settings["memcached"] = {
         "ip": "127.0.0.1",
@@ -163,15 +165,22 @@ def list_to_str(l):
     return " ".join(l) if len(l) > 0 else "no one"
 
 
+<<<<<<< HEAD
 def mail_format_event(event, replies=[], is_reply=False, prefix = ""):
     f = "[%s] %s%s: %s\n"
     d = datetime.utcfromtimestamp(event["origin_server_ts"] / 1000).strftime('%Y-%m-%d %H:%M:%S UTC')
+=======
+def mail_format_event(event, replies=[], hide_matrix_domain=True, prefix=""):
+    f = "[%s]%s%s: %s\n"
+    d = datetime.utcfromtimestamp(event['origin_server_ts'] / 1000).strftime('%Y-%m-%d %H:%M:%S UTC')
+>>>>>>> a7aa717... Add new command forward-to-email
 
     if event['event_id'] in replies:
         event['replies'] = replies[event['event_id']]
     else:
         event['replies'] = []
 
+<<<<<<< HEAD
     if is_reply:
         body = " ".join(event["content"]["body"].split('\n\n')[1:])
     else:
@@ -181,6 +190,19 @@ def mail_format_event(event, replies=[], is_reply=False, prefix = ""):
     for r in reversed(event['replies']):
         content += mail_format_event(r, replies, True,
                                      ''.join([' ' for _ in prefix]) + ' \-> ')
+=======
+    sender = event['sender'].split(':')[0] if hide_matrix_domain else event['sender']
+    if is_reply(event):
+        body = ' '.join(event['content']['body'].split('\n\n')[1:])
+    else:
+        body = event['content']['body']
+        sender = "[%s]" % sender
+    content = f % (d, prefix, sender, body)
+
+    for r in reversed(event['replies']):
+        content += mail_format_event(r, replies, hide_matrix_domain,
+                                     ''.join([' ' for _ in prefix]) + ' ↪️  ')
+>>>>>>> a7aa717... Add new command forward-to-email
     return content
 
 
@@ -188,6 +210,17 @@ def get_in_reply_to(event):
     return  event['content'].get('m.relates_to', {}).get('m.in_reply_to', {}).get('event_id', None)
 
 
+<<<<<<< HEAD
+=======
+def is_reply(event):
+    in_reply_to = get_in_reply_to(event)
+    body = event["content"]["body"]
+    # If the body looks like a reply, remove the first 2 tokens
+    # > <@user:domain.com> body example
+    return in_reply_to and body.startswith('> <@')
+
+
+>>>>>>> a7aa717... Add new command forward-to-email
 class MockBot:
     def __init__(self):
         pass

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,9 @@ setup(
     },
     scripts=[
         "tools/matrix-bot",
-        "tools/matrix-subscriber",
+        "tools/matrix-digest",
         "tools/matrix-echo",
+        "tools/matrix-subscriber",
     ],
     zip_safe=False,
     install_requires=[

--- a/tools/matrix-digest
+++ b/tools/matrix-digest
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+#
+# Author: Pablo Saavedra
+# Maintainer: Pablo Saavedra
+# Contact: saavedra.pablo at gmail.com
+
+import argparse
+import traceback
+import time
+import sys
+
+from matrixbot import utils
+from matrixbot import matrix
+
+## vars ########################################################################
+conffile = "./matrixbot.cfg"
+days = 1
+sendto = "no-reply@example.domain"
+
+## command line options parser #################################################
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--conffile", dest="conffile", default=conffile,
+                    help="Conffile (default: %s)" % conffile)
+parser.add_argument("-s", "--sendto", dest="sendto", default=sendto,
+                    help="Send to (default: %s)" % sendto)
+parser.add_argument("-d", "--days", type=int, dest="days", default=days,
+                    help="Days (default: %s)" % days)
+
+parser.add_argument("room", metavar="ROOM", type=str, help="Room")
+args = parser.parse_args()
+conffile = args.conffile
+days = args.days
+room = args.room
+sendto = args.sendto
+
+# setting up ###################################################################
+settings = utils.get_default_settings()
+utils.setup(conffile, settings)
+logger = utils.create_logger(settings)
+
+
+import time
+import datetime
+
+MAX_ITERS = 10
+
+## main ####################################################################
+if __name__ == '__main__':
+    try:
+        m = matrix.MatrixBot(settings)
+        m.join_rooms(silent=True)
+        token = m.sync_token
+
+        room_id = m.get_real_room_id(room)
+
+        seconds = days * 24 * 3600
+        now = time.time()
+        messages = []
+        replies = {}
+        end = False
+        i = 0
+        max_iters = MAX_ITERS
+        while True:
+            r = m.call_api("get_room_messages", 1, room_id, token, "b", 500)
+            for c in r["chunk"]:
+                if now - seconds > c["origin_server_ts"] / 1000:
+                    end = True
+                    break
+                if c.get("type", "") == "m.room.message":
+                    c_in_reply_to = utils.get_in_reply_to(c)
+                    if c_in_reply_to:
+                        if c_in_reply_to in replies:
+                            replies[c_in_reply_to].append(c)
+                        else:
+                            replies[c_in_reply_to]= [c]
+                    else:
+                        messages.append(c)
+            if end:
+                break
+            i += 1
+            if i == max_iters:
+                logger.warning("Max. iters number reached")
+                break
+            token = r["end"]
+
+        if not len(messages):
+            sys.exit(0)
+
+        content = ""
+        for message in reversed(messages):
+            content += utils.mail_format_event(message, replies)
+
+        aliases = m.get_room_aliases(room_id)
+        message = '''
+Thread forwarded from %s,
+
+- 8< ----------------------------------------------------------------
+
+%s
+- 8< ----------------------------------------------------------------
+
+''' % (aliases if aliases else room, content)
+        try:
+            m.send_mail(message, sendto)
+        except matrix.MatrixBotError as e:
+            traceback.print_exc(e)
+            logger.error("%s" % e)
+        except Exception as e:
+            traceback.print_exc()
+            logger.error("error: %s" % e)
+    except Exception as e:
+        traceback.print_exc()
+        logger.error("Unexpected error: %s" % e)
+


### PR DESCRIPTION
DEPENDS: https://github.com/psaavedra/matrix-bot/pull/54

A convenient tool to sends the DAYS backlog activity of the ROOM to the
SENDTO mailbox. Ideal to use as a cronjob.

There is an maximum harcoded value of 5000 messages.

Example of use:

```
usage: matrix-digest [-h] [-c CONFFILE] [-s SENDTO] [-d DAYS] ROOM

positional arguments:
  ROOM                  Room

optional arguments:
  -h, --help            show this help message and exit
  -c CONFFILE, --conffile CONFFILE
                        Conffile (default: .matrixbot.cfg)
  -s SENDTO, --sendto SENDTO
                        Send to (default: no-reply@example.domain)
  -d DAYS, --days DAYS  Days (default: 1)
```

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>