### PR TITLE
Fix invitations and kicks after upgrade

### DIFF
--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -157,6 +157,7 @@ class MatrixBot():
             room_members = [m.user_id for m in r.get_joined_members()]
             return user_id in room_members
         except Exception as e:
+            self.logger.error("Error when fetching room members: %s" % e)
             return False
         return False
 

--- a/matrixbot/matrix.py
+++ b/matrixbot/matrix.py
@@ -154,7 +154,8 @@ class MatrixBot():
     def is_room_member(self, room_id, user_id):
         try:
             r = Room(self.client, room_id)
-            return user_id in list(r.get_joined_members().keys())
+            room_members = [m.user_id for m in r.get_joined_members()]
+            return user_id in room_members
         except Exception as e:
             return False
         return False


### PR DESCRIPTION
The method `get_joined_members` returns a list of users without
keys, so it's no possible to break it down using the `keys()`
method anymore.

Instead iterate through the list and generate a new one containing only
the `user_id` of all members.

Closes #65 